### PR TITLE
Switch submodule inclusion to format that works anonymously

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/SocketRocket"]
 	path = lib/SocketRocket
 	branch = master
-	url = git@github.com:Troupe/SocketRocket.git
+	url = https://github.com/troupe/FayeObjC.git


### PR DESCRIPTION
It is not possible to clone anonymously using the git@github.com: SSH syntax. Switching to this format will allow CI systems to include this dependency without having to create a GitHub account for the CI system to authenticate.